### PR TITLE
doc: Fix default value for Protocol enum

### DIFF
--- a/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
+++ b/packages/@aws-cdk/aws-ecs/lib/container-definition.ts
@@ -586,7 +586,7 @@ export interface PortMapping {
   /**
    * Protocol
    *
-   * @default Tcp
+   * @default TCP
    */
   readonly protocol?: Protocol
 }


### PR DESCRIPTION
Change the default value for Protocol enum from ``Tcp`` -> ``TCP``

Fixes #3143

----

Please read the [contribution guidelines](https://github.com/awslabs/aws-cdk/blob/master/CONTRIBUTING.md) and follow the pull-request checklist.

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
